### PR TITLE
run tox tests in a github actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to help you get started with Actions
 
-name: CI
+name: Build
 
 # Controls when the workflow will run
 on:

--- a/.github/workflows/tox_tests.yml
+++ b/.github/workflows/tox_tests.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.7']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install ClamAV
+        run: |
+          sudo apt-get install clamav-daemon clamav-freshclam clamav-unofficial-sigs
+          sudo service clamav-freshclam stop
+          sudo freshclam --verbose
+          sudo service clamav-daemon start
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install tox and tox-gh-actions
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install tox tox-gh-actions
+
+      - name: Run tox
+        run: tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,9 @@
 [tox]
-envlist = py{26,27,33,34,35}, lint
+envlist = py{37}, lint
+
+[gh-actions]
+python =
+    3.7: py37, lint
 
 [testenv]
 commands = py.test {posargs}


### PR DESCRIPTION
Migrating CI from Travis to GitHub Actions, utilizing `tox-gh-actions` for Python testing. Includes updates to `tox.ini` and a new `tox_tests.yml`
